### PR TITLE
Implement luck bonus and enhance stat fireworks

### DIFF
--- a/src/main/java/me/continent/ContinentPlugin.java
+++ b/src/main/java/me/continent/ContinentPlugin.java
@@ -34,6 +34,7 @@ import me.continent.command.JobCommand;
 import me.continent.enterprise.EnterpriseTypeConfig;
 import me.continent.nation.gui.NationListListener;
 import me.continent.enterprise.gui.EnterpriseListListener;
+import me.continent.listener.LuckDropListener;
 import org.bukkit.plugin.java.JavaPlugin;
 import me.continent.player.PlayerDataManager;
 import me.continent.command.MarketCommand;
@@ -130,6 +131,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.StatsEffectListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.StatLevelListener(), this);
+        getServer().getPluginManager().registerEvents(new me.continent.listener.LuckDropListener(), this);
 
 
         getServer().getPluginManager().registerEvents(new MarketListener(), this);

--- a/src/main/java/me/continent/listener/LuckDropListener.java
+++ b/src/main/java/me/continent/listener/LuckDropListener.java
@@ -1,0 +1,47 @@
+package me.continent.listener;
+
+import me.continent.player.PlayerDataManager;
+import me.continent.stat.PlayerStats;
+import me.continent.stat.StatType;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class LuckDropListener implements Listener {
+    private static final Material[] RARE_ORES = {
+            Material.DIAMOND_ORE,
+            Material.DEEPSLATE_DIAMOND_ORE,
+            Material.EMERALD_ORE,
+            Material.DEEPSLATE_EMERALD_ORE,
+            Material.ANCIENT_DEBRIS,
+            Material.NETHERITE_BLOCK
+    };
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBreak(BlockBreakEvent event) {
+        Block block = event.getBlock();
+        Material type = block.getType();
+        boolean rare = false;
+        for (Material m : RARE_ORES) {
+            if (m == type) {
+                rare = true;
+                break;
+            }
+        }
+        if (!rare) return;
+
+        PlayerStats stats = PlayerDataManager.get(event.getPlayer().getUniqueId()).getStats();
+        int luck = stats.get(StatType.LUCK);
+        if (luck <= 0) return;
+
+        double chance = luck * 0.05; // 5% per point
+        if (Math.random() < chance) {
+            for (ItemStack drop : block.getDrops(event.getPlayer().getInventory().getItemInMainHand())) {
+                block.getWorld().dropItemNaturally(block.getLocation(), drop);
+            }
+        }
+    }
+}

--- a/src/main/java/me/continent/stat/StatsManager.java
+++ b/src/main/java/me/continent/stat/StatsManager.java
@@ -47,24 +47,38 @@ public class StatsManager {
         applyStats(player);
     }
 
+    private static final Color[] MASTER_COLORS = {
+            Color.fromRGB(0xFFD700),
+            Color.fromRGB(0xFFFF55),
+            Color.fromRGB(0xB366FF)
+    };
+
     private static void launchFireworks(Player player, boolean multiple) {
         if (multiple) {
+            int shots = 3 + (int) (Math.random() * 3);
             new BukkitRunnable() {
                 int count = 0;
                 @Override
                 public void run() {
-                    spawnFirework(player, Color.fromRGB(0xFFDB4D));
+                    Color c = MASTER_COLORS[(int) (Math.random() * MASTER_COLORS.length)];
+                    spawnFirework(player, c, true);
                     count++;
-                    if (count >= 5) cancel();
+                    if (count >= shots) cancel();
                 }
             }.runTaskTimer(ContinentPlugin.getInstance(), 0L, 4L);
         } else {
-            spawnFirework(player, Color.fromRGB(0xFFDB4D));
+            spawnFirework(player, Color.fromRGB(0xFFDB4D), false);
         }
     }
 
-    private static void spawnFirework(Player player, Color color) {
-        Firework fw = (Firework) player.getWorld().spawnEntity(player.getLocation(), EntityType.FIREWORK_ROCKET);
+    private static void spawnFirework(Player player, Color color, boolean around) {
+        org.bukkit.Location loc = player.getLocation();
+        if (around) {
+            double dx = (Math.random() - 0.5) * 4;
+            double dz = (Math.random() - 0.5) * 4;
+            loc = loc.clone().add(dx, 0, dz);
+        }
+        Firework fw = (Firework) player.getWorld().spawnEntity(loc, EntityType.FIREWORK_ROCKET);
         FireworkMeta meta = fw.getFireworkMeta();
         meta.addEffect(FireworkEffect.builder().withColor(color).with(FireworkEffect.Type.STAR).build());
         meta.setPower(0);
@@ -100,8 +114,8 @@ public class StatsManager {
         if (attackSpeedAttr != null) {
             attackSpeedAttr.getModifiers().stream().filter(m -> STR_ATTACK_SPEED_KEY.equals(m.getKey())).forEach(attackSpeedAttr::removeModifier);
             if (str >= 10) {
-                // High value effectively removes cooldown
-                attackSpeedAttr.addTransientModifier(new org.bukkit.attribute.AttributeModifier(STR_ATTACK_SPEED_KEY, 4.0, org.bukkit.attribute.AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.ANY));
+                // Large bonus effectively removes attack cooldown
+                attackSpeedAttr.addTransientModifier(new org.bukkit.attribute.AttributeModifier(STR_ATTACK_SPEED_KEY, 16.0, org.bukkit.attribute.AttributeModifier.Operation.ADD_NUMBER, EquipmentSlotGroup.ANY));
             }
         }
 


### PR DESCRIPTION
## Summary
- add `LuckDropListener` to grant bonus drops when mining rare ores based on luck
- enhance level up fireworks with random colors and spread
- remove attack cooldown when Strength >= 10
- register new listener in plugin

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68882c8566288324a6c0f8b5e0535ec9