### PR TITLE
Apply haste when joining or respawning

### DIFF
--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -69,7 +69,14 @@ public class StatsEffectListener implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        StatsManager.applyStats(event.getPlayer());
+        Player player = event.getPlayer();
+        StatsManager.applyStats(player);
+        PlayerStats stats = PlayerDataManager.get(player.getUniqueId()).getStats();
+        if (stats.get(StatType.STRENGTH) >= 5) {
+            applyHaste(player, player.getInventory().getItemInMainHand());
+        } else {
+            player.removePotionEffect(org.bukkit.potion.PotionEffectType.HASTE);
+        }
     }
 
     @EventHandler
@@ -86,7 +93,16 @@ public class StatsEffectListener implements Listener {
 
     @EventHandler
     public void onRespawn(PlayerRespawnEvent event) {
-        org.bukkit.Bukkit.getScheduler().runTask(me.continent.ContinentPlugin.getInstance(), () -> StatsManager.applyStats(event.getPlayer()));
+        org.bukkit.Bukkit.getScheduler().runTask(me.continent.ContinentPlugin.getInstance(), () -> {
+            Player player = event.getPlayer();
+            StatsManager.applyStats(player);
+            PlayerStats stats = PlayerDataManager.get(player.getUniqueId()).getStats();
+            if (stats.get(StatType.STRENGTH) >= 5) {
+                applyHaste(player, player.getInventory().getItemInMainHand());
+            } else {
+                player.removePotionEffect(org.bukkit.potion.PotionEffectType.HASTE);
+            }
+        });
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- give players haste from the held item as soon as they join or respawn
- remove haste if their current item doesn't qualify

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688830258de883249673bb16f6a326e8