### PR TITLE
Fix BukkitRunnable scheduling

### DIFF
--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -148,7 +148,7 @@ public class StatsEffectListener implements Listener {
         java.util.UUID id = player.getUniqueId();
         org.bukkit.scheduler.BukkitTask old = staminaTasks.remove(id);
         if (old != null) old.cancel();
-        org.bukkit.scheduler.BukkitTask task = org.bukkit.Bukkit.getScheduler().runTaskTimer(me.continent.ContinentPlugin.getInstance(), new org.bukkit.scheduler.BukkitRunnable() {
+        org.bukkit.scheduler.BukkitRunnable runnable = new org.bukkit.scheduler.BukkitRunnable() {
             final long start = System.currentTimeMillis();
             @Override
             public void run() {
@@ -166,7 +166,8 @@ public class StatsEffectListener implements Listener {
                 }
                 sendCooldownBar(player, elapsed, cd);
             }
-        }, 0L, 2L);
+        };
+        org.bukkit.scheduler.BukkitTask task = runnable.runTaskTimer(me.continent.ContinentPlugin.getInstance(), 0L, 2L);
         staminaTasks.put(id, task);
     }
 


### PR DESCRIPTION
## Summary
- fix `startCooldownBar` to run timer via BukkitRunnable

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688840ff4fb88324ba00f0371faa2cb0