### PR TITLE
Fix unresponsive corpse bug with Vitality heal

### DIFF
--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -56,6 +56,9 @@ public class StatsEffectListener implements Listener {
             public void run() {
                 for (Player p : org.bukkit.Bukkit.getOnlinePlayers()) {
                     PlayerStats stats = PlayerDataManager.get(p.getUniqueId()).getStats();
+                    if (p.isDead() || p.getHealth() <= 0.0) {
+                        continue;
+                    }
                     int vit = stats.get(StatType.VITALITY);
                     if (vit >= 5 && p.getFoodLevel() > 6 && p.getHealth() < p.getAttribute(org.bukkit.attribute.Attribute.MAX_HEALTH).getValue()) {
                         p.setHealth(Math.min(p.getHealth() + 0.5, p.getAttribute(org.bukkit.attribute.Attribute.MAX_HEALTH).getValue()));


### PR DESCRIPTION
## Summary
- ignore players that are already dead when running the scheduled Vitality heal check

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68884f4740bc83248331abca2737f891