### PR TITLE
Add admin stat point management

### DIFF
--- a/src/main/java/me/continent/stat/PlayerStats.java
+++ b/src/main/java/me/continent/stat/PlayerStats.java
@@ -39,6 +39,14 @@ public class PlayerStats {
         return unusedPoints;
     }
 
+    /**
+     * Sets the number of unused stat points the player currently has.
+     * Negative values are clamped to zero.
+     */
+    public void setPoints(int amount) {
+        this.unusedPoints = Math.max(0, amount);
+    }
+
     public void addPoints(int amount) {
         this.unusedPoints += amount;
     }


### PR DESCRIPTION
## Summary
- add `setPoints` method to `PlayerStats`
- extend `/admin` command to manage player stat points

## Testing
- `./gradlew clean build`

------
https://chatgpt.com/codex/tasks/task_e_6888586c467883248ae83a17e7570a0b