### PR TITLE
Improve stats command and adjust fall damage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Gradle build directories
+.gradle/
+build/
+
+# IDE files
+*.iml
+.idea/

--- a/src/main/java/me/continent/command/StatCommand.java
+++ b/src/main/java/me/continent/command/StatCommand.java
@@ -28,9 +28,13 @@ public class StatCommand implements TabExecutor {
             for (StatType type : StatType.values()) {
                 player.sendMessage("§e" + type.name() + ": §f" + stats.get(type));
             }
+            if (stats.getMastery() != null) {
+                player.sendMessage("§e마스터리: §f" + stats.getMastery().name());
+            }
             player.sendMessage("남은 포인트: " + stats.getUnusedPoints());
             return true;
         }
+
         if (args[0].equalsIgnoreCase("add") && args.length >= 2) {
             if (stats.getUnusedPoints() <= 0) {
                 player.sendMessage("§c사용 가능한 포인트가 없습니다.");
@@ -61,15 +65,40 @@ public class StatCommand implements TabExecutor {
             }
             return true;
         }
+
+        if (args[0].equalsIgnoreCase("remove") && args.length >= 2) {
+            try {
+                StatType type = StatType.valueOf(args[1].toUpperCase(Locale.ROOT));
+                if (stats.refundPoint(type)) {
+                    PlayerDataManager.save(player.getUniqueId());
+                    player.sendMessage("§a" + type.name() + " -1 (" + stats.get(type) + ")");
+                    me.continent.stat.StatsManager.applyStats(player);
+                } else {
+                    player.sendMessage("§c해당 스탯에 투자된 포인트가 없습니다.");
+                }
+            } catch (IllegalArgumentException e) {
+                player.sendMessage("§c잘못된 스탯입니다.");
+            }
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("reset")) {
+            stats.resetAll();
+            PlayerDataManager.save(player.getUniqueId());
+            me.continent.stat.StatsManager.applyStats(player);
+            player.sendMessage("§a스탯을 초기화했습니다. 사용 가능한 포인트: " + stats.getUnusedPoints());
+            return true;
+        }
+
         return false;
     }
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
         if (args.length == 1) {
-            return List.of("add");
+            return List.of("add", "remove", "reset");
         }
-        if (args.length == 2 && args[0].equalsIgnoreCase("add")) {
+        if (args.length == 2 && (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("remove"))) {
             List<String> list = new ArrayList<>();
             for (StatType type : StatType.values()) list.add(type.name().toLowerCase(Locale.ROOT));
             return list;

--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -191,7 +191,6 @@ public class StatsEffectListener implements Listener {
         if (stats.get(StatType.AGILITY) >= 10 && player.getGameMode() == GameMode.SURVIVAL) {
             if (player.isOnGround()) {
                 player.setAllowFlight(true);
-                jumped.put(player.getUniqueId(), false);
             }
         }
     }

--- a/src/main/java/me/continent/stat/PlayerStats.java
+++ b/src/main/java/me/continent/stat/PlayerStats.java
@@ -55,6 +55,34 @@ public class PlayerStats {
         if (unusedPoints > 0) unusedPoints--;
     }
 
+    /**
+     * Removes one point from the given stat if possible.
+     * Returns true if a point was removed.
+     */
+    public boolean refundPoint(StatType type) {
+        int current = get(type);
+        if (current <= 0) return false;
+        stats.put(type, current - 1);
+        unusedPoints++;
+        if (current - 1 < 11 && mastery == type) {
+            mastery = null;
+        }
+        return true;
+    }
+
+    /**
+     * Resets all stats, converting invested points back to unused points.
+     */
+    public void resetAll() {
+        int total = 0;
+        for (StatType type : StatType.values()) {
+            total += get(type);
+            stats.put(type, 0);
+        }
+        unusedPoints += total;
+        mastery = null;
+    }
+
     public int getLastLevelGiven() {
         return lastLevelGiven;
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -43,4 +43,4 @@ commands:
     usage: /job <subcommand>
   stat:
     description: Player stat management
-    usage: /stat <add>
+    usage: /stat <add|remove|reset>


### PR DESCRIPTION
## Summary
- expand `PlayerStats` with point refund and full reset capabilities
- add `/stat remove` and `/stat reset` for players
- show mastery info in `/stat`
- update tab completion and plugin.yml docs
- tweak `StatsEffectListener` so double jump doesn't clear fall damage flag
- add `.gitignore`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6888634fc4b08324a05f1ec282d2da0a