### PR TITLE
Fix fall damage at high agility

### DIFF
--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -284,6 +284,13 @@ public class StatsEffectListener implements Listener {
             int agi = stats.get(StatType.AGILITY);
             if (event.getCause() == EntityDamageEvent.DamageCause.FALL) {
                 jumped.put(player.getUniqueId(), false);
+                if (agi >= 10) {
+                    float dist = player.getFallDistance();
+                    double computed = Math.max(0, dist - 3.0);
+                    if (computed > event.getDamage()) {
+                        event.setDamage(computed);
+                    }
+                }
             }
             if (vit >= 14) {
                 switch (event.getCause()) {


### PR DESCRIPTION
## Summary
- ensure fall damage applies for players with Agility 10 or higher

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68886b6c9fbc83248b1d594f953abb87