### PR TITLE
Add war statistics and command updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Continent 플러그인은 마인크래프트 서버에서 국가 체계와 경�
 - **중앙은행**  
   거래량에 따라 환율이 변동되며 서버 종료 시 `centralbank.yml`에 환율이 저장됩니다.
 - **국가 관리**
-  `/nation` 명령을 통해 국가 생성(`create`)과 해산(`disband`), 영토 점령/해제(`claim`, `unclaim`), 초대(`invite`, `accept`, `deny`, `invites`)와 추방(`kick`), 구성원 목록(`members`), 탈퇴(`leave`), 국가명 변경(`rename`), 색상 변경(`color`), 국가 금고 관리(`treasury balance|deposit|withdraw`), 스폰 설정 및 이동(`setspawn`, `spawn`), 코어 위치 지정(`setcore`), 국가 창고(`chest`), 인벤토리 기반의 관리 메뉴(`menu`), 점화 허용 토글(`ignite`), 국가 채팅 토글(`chat`), 명령 확인(`confirm`), 서버 내 국가 목록(`list`) 등 모든 행정 명령이 제공됩니다.
+  `/nation` 명령을 통해 국가 생성(`create`)과 해산(`disband`), 영토 점령/해제(`claim`, `unclaim`), 초대(`invite`, `accept`, `deny`, `invites`)와 추방(`kick`), 구성원 목록(`members`), 탈퇴(`leave`), 국가명 변경(`rename`), 색상 변경(`color`), 국가 금고 관리(`treasury balance|deposit|withdraw`), 스폰 설정 및 이동(`setspawn`, `spawn`), 코어 위치 지정(`setcore`), 국가 창고(`chest`), 인벤토리 기반의 관리 메뉴(`/nation`), 점화 허용 토글(`ignite`), 국가 채팅 토글(`chat`), 명령 확인(`confirm`), 서버 내 국가 목록(`list`) 등 모든 행정 명령이 제공됩니다.
 - **국가 창고**
   27칸의 전용 인벤토리를 제공하며 내용물은 자동 저장됩니다.
 - **영토 및 코어 보호**  

--- a/USER_TUTORIAL.md
+++ b/USER_TUTORIAL.md
@@ -19,7 +19,7 @@
 - `nation treasury balance|deposit|withdraw` : 국가 금고 관리
 - `nation setspawn` / `nation spawn` : 국가 스폰 위치 설정 및 이동
 - `nation chest` : 국가 전용 창고 열기
-- `nation menu` : GUI 기반 관리 메뉴
+- `nation` : GUI 기반 관리 메뉴
 
 국가별로 고유한 색상과 이름을 지정할 수 있으며 모든 국가는 주간 유지비를 납부해야 합니다.
 

--- a/src/main/java/me/continent/ContinentPlugin.java
+++ b/src/main/java/me/continent/ContinentPlugin.java
@@ -27,6 +27,7 @@ import me.continent.nation.service.NationMenuListener;
 import me.continent.nation.service.NationTreasuryListener;
 import me.continent.nation.service.NationMemberListener;
 import me.continent.nation.service.NationUpkeepListener;
+import me.continent.nation.service.NationWarStatsListener;
 import me.continent.menu.ServerMenuListener;
 import me.continent.job.JobManager;
 import me.continent.job.JobMenuListener;
@@ -121,6 +122,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new NationTreasuryListener(), this);
         getServer().getPluginManager().registerEvents(new NationMemberListener(), this);
         getServer().getPluginManager().registerEvents(new NationUpkeepListener(), this);
+        getServer().getPluginManager().registerEvents(new NationWarStatsListener(), this);
         getServer().getPluginManager().registerEvents(new ServerMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.economy.gui.GoldMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.enterprise.gui.EnterpriseMenuListener(), this);

--- a/src/main/java/me/continent/command/NationCommand.java
+++ b/src/main/java/me/continent/command/NationCommand.java
@@ -29,34 +29,17 @@ public class NationCommand implements TabExecutor {
         }
 
         if (args.length == 0) {
-            player.sendMessage("§6[Nation 명령어 도움말]");
-            player.sendMessage("§e/nation create <이름> §7- 국가 또는 국가 생성");
-            player.sendMessage("§e/nation disband §7- 국가 해산");
-            player.sendMessage("§e/nation claim §7- 청크 점령");
-            player.sendMessage("§e/nation invite <플레이어> §7- 초대 전송");
-            player.sendMessage("§e/nation invites §7- 받은 초대 목록 확인");
-            player.sendMessage("§e/nation accept <이름> §7- 초대 수락");
-            player.sendMessage("§e/nation deny <이름> §7- 초대 거절");
-            player.sendMessage("§e/nation members §7- 국가 구성원 확인");
-            player.sendMessage("§e/nation leave §7- 국가 탈퇴");
-            player.sendMessage("§e/nation kick <플레이어> §7- 구성원 추방");
-            player.sendMessage("§e/nation rename <새이름> §7- 국가 이름 변경");
-            player.sendMessage("§e/nation list §7- 서버 내 모든 국가 목록");
-            player.sendMessage("§e/nation setspawn §7- 국가 스폰 위치 설정");
-            player.sendMessage("§e/nation setcore §7- 코어 위치 이동");
-            player.sendMessage("§e/nation spawn §7- 국가 스폰으로 이동");
-            player.sendMessage("§e/nation chest §7- 국가 창고 열기");
-            player.sendMessage("§e/nation menu §7- 국가 메뉴 열기");
-            player.sendMessage("§e/nation setsymbol §7- 상징 아이템 설정");
-            player.sendMessage("§e/nation ignite <on|off> §7- 아군 점화 허용 토글");
-            player.sendMessage("§e/nation upkeep §7- 현재 유지비 확인");
-            player.sendMessage("§e/nation treasury <subcommand> §7- 금고 관리");
-            player.sendMessage("§e/nation specialty §7- 특산품 관리");
-            player.sendMessage("§e/nation upgrade §7- 국가 등급 승격 시도");
-            player.sendMessage("§e/nation tier §7- 현재 국가 등급 확인");
-            player.sendMessage("§e/nation tierinfo §7- 등급별 기능 안내");
-            player.sendMessage("§e/nation confirm §7- 대기 중인 작업 확인");
-            player.sendMessage("§e/nation chat §7- 국가 채팅 토글");
+            Nation nation = NationManager.getByPlayer(player.getUniqueId());
+            if (nation == null) {
+                player.sendMessage("§c소속된 국가가 없습니다.");
+                return true;
+            }
+            NationMenuService.openMenu(player, nation);
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("help")) {
+            sendHelp(player);
             return true;
         }
 
@@ -694,7 +677,7 @@ public class NationCommand implements TabExecutor {
             return true;
         }
 
-        player.sendMessage("§c알 수 없는 하위 명령어입니다. /nation 을 입력해 도움말을 확인하세요.");
+        player.sendMessage("§c알 수 없는 하위 명령어입니다. /nation help 로 도움말을 확인하세요.");
         return true;
     }
 
@@ -703,7 +686,7 @@ public class NationCommand implements TabExecutor {
         List<String> subs = Arrays.asList(
                 "create", "disband", "claim", "invite", "invites", "accept", "deny",
                 "members", "leave", "kick", "rename", "list", "setspawn", "setcore",
-                "spawn", "chest", "menu", "setsymbol", "ignite", "upkeep", "treasury", "specialty", "upgrade", "tier", "tierinfo", "confirm", "chat"
+                "spawn", "chest", "menu", "setsymbol", "ignite", "upkeep", "treasury", "specialty", "upgrade", "tier", "tierinfo", "confirm", "chat", "help"
         );
 
         if (args.length == 1) {
@@ -727,5 +710,36 @@ public class NationCommand implements TabExecutor {
         }
 
         return Collections.emptyList();
+    }
+
+    private static void sendHelp(Player player) {
+        player.sendMessage("§6[Nation 명령어 도움말]");
+        player.sendMessage("§e/nation create <이름> §7- 국가 또는 국가 생성");
+        player.sendMessage("§e/nation disband §7- 국가 해산");
+        player.sendMessage("§e/nation claim §7- 청크 점령");
+        player.sendMessage("§e/nation invite <플레이어> §7- 초대 전송");
+        player.sendMessage("§e/nation invites §7- 받은 초대 목록 확인");
+        player.sendMessage("§e/nation accept <이름> §7- 초대 수락");
+        player.sendMessage("§e/nation deny <이름> §7- 초대 거절");
+        player.sendMessage("§e/nation members §7- 국가 구성원 확인");
+        player.sendMessage("§e/nation leave §7- 국가 탈퇴");
+        player.sendMessage("§e/nation kick <플레이어> §7- 구성원 추방");
+        player.sendMessage("§e/nation rename <새이름> §7- 국가 이름 변경");
+        player.sendMessage("§e/nation list §7- 서버 내 모든 국가 목록");
+        player.sendMessage("§e/nation setspawn §7- 국가 스폰 위치 설정");
+        player.sendMessage("§e/nation setcore §7- 코어 위치 이동");
+        player.sendMessage("§e/nation spawn §7- 국가 스폰으로 이동");
+        player.sendMessage("§e/nation chest §7- 국가 창고 열기");
+        player.sendMessage("§e/nation setsymbol §7- 상징 아이템 설정");
+        player.sendMessage("§e/nation ignite <on|off> §7- 아군 점화 허용 토글");
+        player.sendMessage("§e/nation upkeep §7- 현재 유지비 확인");
+        player.sendMessage("§e/nation treasury <subcommand> §7- 금고 관리");
+        player.sendMessage("§e/nation specialty §7- 특산품 관리");
+        player.sendMessage("§e/nation upgrade §7- 국가 등급 승격 시도");
+        player.sendMessage("§e/nation tier §7- 현재 국가 등급 확인");
+        player.sendMessage("§e/nation tierinfo §7- 등급별 기능 안내");
+        player.sendMessage("§e/nation confirm §7- 대기 중인 작업 확인");
+        player.sendMessage("§e/nation chat §7- 국가 채팅 토글");
+        player.sendMessage("§e/nation menu §7- 국가 메뉴 열기");
     }
 }

--- a/src/main/java/me/continent/nation/Nation.java
+++ b/src/main/java/me/continent/nation/Nation.java
@@ -45,6 +45,10 @@ public class Nation {
     private final Set<String> selectedT4Nodes = new HashSet<>();
     private int researchSlots = 1;
 
+    // War statistics
+    private int warWins = 0;
+    private int warLosses = 0;
+
 
     public Nation(String name, UUID king) {
         this.name = name;
@@ -193,6 +197,15 @@ public class Nation {
     public void setResearchSlots(int slots) {
         this.researchSlots = slots;
     }
+
+    // ---- War stats ----
+    public int getWarWins() { return warWins; }
+
+    public void setWarWins(int wins) { this.warWins = wins; }
+
+    public int getWarLosses() { return warLosses; }
+
+    public void setWarLosses(int losses) { this.warLosses = losses; }
 
 
     public long getProtectionEnd() { return protectionEnd; }

--- a/src/main/java/me/continent/nation/service/NationMenuListener.java
+++ b/src/main/java/me/continent/nation/service/NationMenuListener.java
@@ -36,6 +36,8 @@ public class NationMenuListener implements Listener {
                 }
             } else if (slot == 25) {
                 ChestService.openChest(player, nation);
+            } else if (slot == 33) {
+                NationWarStatsService.openMenu(player, nation);
             } else if (slot == 31) {
                 ServerMenuService.openMenu(player);
             }

--- a/src/main/java/me/continent/nation/service/NationMenuService.java
+++ b/src/main/java/me/continent/nation/service/NationMenuService.java
@@ -39,6 +39,7 @@ public class NationMenuService {
         inv.setItem(29, createItem(Material.PAPER, "세금 정보"));
         inv.setItem(23, createItem(Material.COMPASS, "국가 스폰 이동"));
         inv.setItem(25, createItem(Material.CHEST, "국가 창고"));
+        inv.setItem(33, createItem(Material.IRON_SWORD, "전쟁 통계"));
         inv.setItem(31, createItem(Material.ARROW, "메인 메뉴"));
 
         player.openInventory(inv);

--- a/src/main/java/me/continent/nation/service/NationWarStatsListener.java
+++ b/src/main/java/me/continent/nation/service/NationWarStatsListener.java
@@ -1,0 +1,24 @@
+package me.continent.nation.service;
+
+import me.continent.nation.Nation;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+/** Listener for the war statistics menu. */
+public class NationWarStatsListener implements Listener {
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        Inventory inv = event.getInventory();
+        if (inv.getHolder() instanceof NationWarStatsService.StatsHolder holder) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            Nation nation = holder.getNation();
+            if (event.getRawSlot() == 26) {
+                NationMenuService.openMenu(player, nation);
+            }
+        }
+    }
+}

--- a/src/main/java/me/continent/nation/service/NationWarStatsService.java
+++ b/src/main/java/me/continent/nation/service/NationWarStatsService.java
@@ -1,0 +1,53 @@
+package me.continent.nation.service;
+
+import me.continent.nation.Nation;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+/** Simple GUI showing war statistics for a nation. */
+public class NationWarStatsService {
+    public static void openMenu(Player player, Nation nation) {
+        StatsHolder holder = new StatsHolder(nation);
+        Inventory inv = Bukkit.createInventory(holder, 27, "War Statistics");
+        holder.setInventory(inv);
+        render(inv, nation);
+        player.openInventory(inv);
+    }
+
+    static void render(Inventory inv, Nation nation) {
+        inv.clear();
+        ItemStack info = item(Material.IRON_SWORD, "전쟁 통계");
+        ItemMeta meta = info.getItemMeta();
+        meta.setLore(List.of(
+                "§7승리: " + nation.getWarWins() + "회",
+                "§7패배: " + nation.getWarLosses() + "회"
+        ));
+        info.setItemMeta(meta);
+        inv.setItem(13, info);
+        inv.setItem(26, item(Material.ARROW, "메인 메뉴"));
+    }
+
+    private static ItemStack item(Material mat, String name) {
+        ItemStack is = new ItemStack(mat);
+        ItemMeta meta = is.getItemMeta();
+        meta.setDisplayName(name);
+        is.setItemMeta(meta);
+        return is;
+    }
+
+    static class StatsHolder implements InventoryHolder {
+        private final Nation nation;
+        private Inventory inv;
+        StatsHolder(Nation n) { this.nation = n; }
+        void setInventory(Inventory inv) { this.inv = inv; }
+        @Override public Inventory getInventory() { return inv; }
+        public Nation getNation() { return nation; }
+    }
+}

--- a/src/main/java/me/continent/storage/NationStorage.java
+++ b/src/main/java/me/continent/storage/NationStorage.java
@@ -56,6 +56,8 @@ public class NationStorage {
         config.set("maintenanceCount", nation.getMaintenanceCount());
         config.set("unpaidWeeks", nation.getUnpaidWeeks());
         config.set("lastMaintenance", nation.getLastMaintenance());
+        config.set("warWins", nation.getWarWins());
+        config.set("warLosses", nation.getWarLosses());
 
         try {
             config.save(file);
@@ -87,6 +89,8 @@ public class NationStorage {
             int maintenanceCount = config.getInt("maintenanceCount", 0);
             int unpaidWeeks = config.getInt("unpaidWeeks", 0);
             long lastMaintenance = config.getLong("lastMaintenance", 0);
+            int warWins = config.getInt("warWins", 0);
+            int warLosses = config.getInt("warLosses", 0);
             
 
             Nation nation = new Nation(name, king);
@@ -107,6 +111,8 @@ public class NationStorage {
             nation.setLastMaintenance(lastMaintenance);
             nation.setCoreChunkKey(config.getString("core-chunk"));
             nation.setSpawnChunkKey(config.getString("spawn-chunk"));
+            nation.setWarWins(warWins);
+            nation.setWarLosses(warLosses);
 
             NationManager.register(nation);
         }

--- a/src/main/java/me/continent/war/WarManager.java
+++ b/src/main/java/me/continent/war/WarManager.java
@@ -69,9 +69,16 @@ public class WarManager {
         War war = getWar(loser.getName());
         if (war == null) return;
         endWar(war);
-        String winner = war.getAttacker().equalsIgnoreCase(loser.getName())
+        String winnerName = war.getAttacker().equalsIgnoreCase(loser.getName())
                 ? war.getDefender() : war.getAttacker();
-        Bukkit.broadcastMessage("§e[전쟁] §f" + loser.getName() + " 국가이 항복했습니다. 승자는 " + winner + " 국가입니다.");
+        Nation winner = NationManager.getByName(winnerName);
+        if (winner != null) {
+            winner.setWarWins(winner.getWarWins() + 1);
+            NationStorage.save(winner);
+        }
+        loser.setWarLosses(loser.getWarLosses() + 1);
+        NationStorage.save(loser);
+        Bukkit.broadcastMessage("§e[전쟁] §f" + loser.getName() + " 국가이 항복했습니다. 승자는 " + winnerName + " 국가입니다.");
     }
 
     public static void coreDestroyed(Nation nation, Nation attacker) {


### PR DESCRIPTION
## Summary
- support a `/nation` command to open the nation menu and move help to `/nation help`
- track war wins and losses for each nation
- show war statistics in the nation menu
- add war statistics GUI and listener
- store war stats in nation data

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6889a017f6e48324b292dfdc88a754e8