### PR TITLE
feat: allow runtime config updates

### DIFF
--- a/src/main/java/me/continent/command/AdminCommand.java
+++ b/src/main/java/me/continent/command/AdminCommand.java
@@ -11,6 +11,8 @@ import me.continent.player.PlayerDataManager;
 import me.continent.stat.PlayerStats;
 import me.continent.season.Season;
 import me.continent.season.SeasonManager;
+import me.continent.scoreboard.ScoreboardService;
+import me.continent.ContinentPlugin;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -49,6 +51,13 @@ public class AdminCommand implements TabExecutor {
             sender.sendMessage("§e/admin stat add <플레이어> <수량> §7- 스탯 포인트 지급");
             sender.sendMessage("§e/admin stat remove <플레이어> <수량> §7- 스탯 포인트 차감");
             sender.sendMessage("§e/admin stat set <플레이어> <수량> §7- 스탯 포인트 설정");
+            sender.sendMessage("§e/admin scoreboard get §7- 스코어보드 설정 확인");
+            sender.sendMessage("§e/admin scoreboard title <제목> §7- 스코어보드 제목 설정");
+            sender.sendMessage("§e/admin scoreboard showcoords <true|false> §7- 좌표 표시 토글");
+            sender.sendMessage("§e/admin scoreboard minimap <크기> §7- 미니맵 크기 설정");
+            sender.sendMessage("§e/admin scoreboard refresh <초> §7- 갱신 주기 설정");
+            sender.sendMessage("§e/admin config get <경로> §7- 설정값 확인");
+            sender.sendMessage("§e/admin config set <경로> <값> §7- 설정값 변경");
             return true;
         }
 
@@ -232,6 +241,109 @@ public class AdminCommand implements TabExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("config")) {
+            ContinentPlugin plugin = ContinentPlugin.getInstance();
+            var config = plugin.getConfig();
+
+            if (args.length >= 3 && args[1].equalsIgnoreCase("get")) {
+                String path = args[2];
+                Object value = config.get(path);
+                if (value == null) {
+                    sender.sendMessage("§c경로를 찾을 수 없습니다.");
+                } else {
+                    sender.sendMessage("§6[설정] §f" + path + " = §e" + value);
+                }
+                return true;
+            }
+
+            if (args.length >= 4 && args[1].equalsIgnoreCase("set")) {
+                String path = args[2];
+                String raw = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
+                Object val;
+                if (raw.equalsIgnoreCase("true") || raw.equalsIgnoreCase("false")) {
+                    val = Boolean.parseBoolean(raw);
+                } else {
+                    try {
+                        val = Integer.parseInt(raw);
+                    } catch (NumberFormatException e1) {
+                        try {
+                            val = Double.parseDouble(raw);
+                        } catch (NumberFormatException e2) {
+                            val = raw;
+                        }
+                    }
+                }
+                config.set(path, val);
+                plugin.saveConfig();
+                sender.sendMessage("§6[설정] §f" + path + " 을(를) " + val + " 로 설정했습니다.");
+                return true;
+            }
+
+            sender.sendMessage("§c사용법: /admin config <get|set> <경로> [값]");
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("scoreboard")) {
+            ContinentPlugin plugin = ContinentPlugin.getInstance();
+            var config = plugin.getConfig();
+
+            if (args.length >= 2 && args[1].equalsIgnoreCase("get")) {
+                sender.sendMessage("§6[스코어보드] §f제목: §e" + config.getString("scoreboard.title"));
+                sender.sendMessage("§6[스코어보드] §f미니맵 크기: §e" + config.getInt("scoreboard.minimap-size"));
+                sender.sendMessage("§6[스코어보드] §f좌표 표시: §e" + config.getBoolean("scoreboard.show-coordinates"));
+                sender.sendMessage("§6[스코어보드] §f갱신 주기: §e" + config.getDouble("scoreboard.refresh-interval"));
+                return true;
+            }
+
+            if (args.length >= 3 && args[1].equalsIgnoreCase("title")) {
+                String title = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
+                config.set("scoreboard.title", title);
+                plugin.saveConfig();
+                Bukkit.getOnlinePlayers().forEach(ScoreboardService::update);
+                sender.sendMessage("§6[스코어보드] §f제목을 설정했습니다.");
+                return true;
+            }
+
+            if (args.length >= 3 && args[1].equalsIgnoreCase("showcoords")) {
+                boolean flag = Boolean.parseBoolean(args[2]);
+                config.set("scoreboard.show-coordinates", flag);
+                plugin.saveConfig();
+                Bukkit.getOnlinePlayers().forEach(ScoreboardService::update);
+                sender.sendMessage("§6[스코어보드] §f좌표 표시를 " + flag + " 로 설정했습니다.");
+                return true;
+            }
+
+            if (args.length >= 3 && args[1].equalsIgnoreCase("minimap")) {
+                try {
+                    int size = Integer.parseInt(args[2]);
+                    config.set("scoreboard.minimap-size", size);
+                    plugin.saveConfig();
+                    Bukkit.getOnlinePlayers().forEach(ScoreboardService::update);
+                    sender.sendMessage("§6[스코어보드] §f미니맵 크기를 " + size + "로 설정했습니다.");
+                } catch (NumberFormatException e) {
+                    sender.sendMessage("§c숫자를 입력해야 합니다.");
+                }
+                return true;
+            }
+
+            if (args.length >= 3 && args[1].equalsIgnoreCase("refresh")) {
+                try {
+                    double seconds = Double.parseDouble(args[2]);
+                    config.set("scoreboard.refresh-interval", seconds);
+                    plugin.saveConfig();
+                    Bukkit.getScheduler().cancelTasks(plugin);
+                    ScoreboardService.schedule();
+                    sender.sendMessage("§6[스코어보드] §f갱신 주기를 " + seconds + "초로 설정했습니다.");
+                } catch (NumberFormatException e) {
+                    sender.sendMessage("§c숫자를 입력해야 합니다.");
+                }
+                return true;
+            }
+
+            sender.sendMessage("§c사용법: /admin scoreboard <get|title|showcoords|minimap|refresh>");
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("stat")) {
             if (args.length < 4) {
                 sender.sendMessage("§c사용법: /admin stat <add|remove|set> <플레이어> <수량>");
@@ -271,7 +383,7 @@ public class AdminCommand implements TabExecutor {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("war", "rate", "maintenance", "season", "stat").stream()
+            return Arrays.asList("war", "rate", "maintenance", "season", "config", "scoreboard", "stat").stream()
                     .filter(s -> s.startsWith(args[0].toLowerCase()))
                     .toList();
         }
@@ -315,6 +427,18 @@ public class AdminCommand implements TabExecutor {
                     .toList();
         }
 
+        if (args.length == 2 && args[0].equalsIgnoreCase("config")) {
+            return Arrays.asList("get", "set").stream()
+                    .filter(s -> s.startsWith(args[1].toLowerCase()))
+                    .toList();
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("scoreboard")) {
+            return Arrays.asList("get", "title", "showcoords", "minimap", "refresh").stream()
+                    .filter(s -> s.startsWith(args[1].toLowerCase()))
+                    .toList();
+        }
+
         if (args.length == 2 && args[0].equalsIgnoreCase("maintenance")) {
             return Arrays.asList("get", "setcost", "setperchunk", "setlimit").stream()
                     .filter(s -> s.startsWith(args[1].toLowerCase()))
@@ -343,6 +467,12 @@ public class AdminCommand implements TabExecutor {
 
         if (args.length == 3 && args[0].equalsIgnoreCase("maintenance")) {
             return List.of();
+        }
+
+        if (args.length == 3 && args[0].equalsIgnoreCase("scoreboard") && args[1].equalsIgnoreCase("showcoords")) {
+            return Arrays.asList("true", "false").stream()
+                    .filter(s -> s.startsWith(args[2].toLowerCase()))
+                    .toList();
         }
 
         return Collections.emptyList();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,9 +24,9 @@ commands:
     description: Specialty goods command
     aliases: [spc]
     usage: /specialty <subcommand>
-  admin:
-    description: Manage wars, economy, maintenance and seasons
-    usage: /admin <subcommand>
+    admin:
+      description: Manage wars, economy, maintenance, seasons, scoreboard and config
+      usage: /admin <subcommand>
   union:
     description: Manage unions of nations
     aliases: [u]


### PR DESCRIPTION
## Summary
- add `/admin config` subcommands for querying and setting arbitrary plugin configuration keys at runtime
- update plugin description to mention configuration management

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688f72abe71c83248cb742a4f5791a8d