### PR TITLE
Refactor invite and stat management

### DIFF
--- a/src/main/java/me/continent/listener/StatsEffectListener.java
+++ b/src/main/java/me/continent/listener/StatsEffectListener.java
@@ -217,12 +217,16 @@ public class StatsEffectListener implements Listener {
         PlayerStats stats = PlayerDataManager.get(player.getUniqueId()).getStats();
         DashState state = getDashState(player);
         if (player.isOnGround()) {
-            state.fallDistance = 0;
-            if (stats.get(StatType.AGILITY) >= 10 && player.getGameMode() == GameMode.SURVIVAL) {
-                player.setAllowFlight(true);
-                state.jumped = false;
-            } else if (player.getAllowFlight()) {
-                player.setAllowFlight(false);
+            if (player.getFallDistance() == 0) {
+                state.fallDistance = 0;
+            }
+            if (player.getGameMode() == GameMode.SURVIVAL) {
+                if (stats.get(StatType.AGILITY) >= 10) {
+                    player.setAllowFlight(true);
+                    state.jumped = false;
+                } else if (player.getAllowFlight()) {
+                    player.setAllowFlight(false);
+                }
             }
         } else {
             state.fallDistance += Math.max(0, event.getFrom().getY() - event.getTo().getY());

--- a/src/main/java/me/continent/nation/NationManager.java
+++ b/src/main/java/me/continent/nation/NationManager.java
@@ -166,17 +166,22 @@ public class NationManager {
         return nationsByName.get(name.toLowerCase());
     }
 
-    // 초대 목록에서 해당 국가 제거
-    public static void removeInvite(UUID playerUUID, String nationName) {
-        Set<String> invites = playerInvites.get(playerUUID);
-        if (invites != null) {
-            invites.remove(nationName);
-        }
+    // 초대 목록에 국가 추가
+    public static void addInvite(UUID playerUUID, String nationName) {
+        playerInvites.computeIfAbsent(playerUUID, k -> new HashSet<>()).add(nationName);
     }
 
-    // 플레이어의 초대 목록 반환
+    // 초대 목록에서 해당 국가 제거
+    public static void removeInvite(UUID playerUUID, String nationName) {
+        playerInvites.computeIfPresent(playerUUID, (uuid, invites) -> {
+            invites.remove(nationName);
+            return invites.isEmpty() ? null : invites;
+        });
+    }
+
+    // 플레이어의 초대 목록 반환 (수정 불가 뷰 제공)
     public static Set<String> getInvites(UUID playerUUID) {
-        return playerInvites.getOrDefault(playerUUID, new HashSet<>());
+        return Collections.unmodifiableSet(playerInvites.getOrDefault(playerUUID, Collections.emptySet()));
     }
 
 

--- a/src/main/java/me/continent/stat/StatType.java
+++ b/src/main/java/me/continent/stat/StatType.java
@@ -1,9 +1,59 @@
 package me.continent.stat;
 
+import me.continent.ContinentPlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlotGroup;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
 public enum StatType {
-    STRENGTH,
-    AGILITY,
-    INTELLIGENCE,
-    VITALITY,
-    LUCK
+    STRENGTH((player, points) -> {
+        apply(player, Attribute.ATTACK_DAMAGE, "str_damage", points * 0.2, AttributeModifier.Operation.ADD_NUMBER);
+        apply(player, Attribute.ATTACK_KNOCKBACK, "str_knockback", points >= 14 ? 1.0 : 0.0, AttributeModifier.Operation.ADD_NUMBER);
+        apply(player, Attribute.ATTACK_SPEED, "str_attack_speed", points >= 10 ? 16.0 : 0.0, AttributeModifier.Operation.ADD_NUMBER);
+    }),
+    AGILITY((player, points) -> {
+        apply(player, Attribute.MOVEMENT_SPEED, "agi_speed", 0.05 * points, AttributeModifier.Operation.MULTIPLY_SCALAR_1);
+    }),
+    INTELLIGENCE((player, points) -> {
+        // no direct effect yet
+    }),
+    VITALITY((player, points) -> {
+        apply(player, Attribute.MAX_HEALTH, "vit_health", points * 2.0, AttributeModifier.Operation.ADD_NUMBER);
+        var healthAttr = player.getAttribute(Attribute.MAX_HEALTH);
+        if (healthAttr != null && player.getHealth() > healthAttr.getValue()) {
+            player.setHealth(healthAttr.getValue());
+        }
+    }),
+    LUCK((player, points) -> {
+        // no direct effect yet
+    });
+
+    private final BiConsumer<Player, Integer> applier;
+
+    StatType(BiConsumer<Player, Integer> applier) {
+        this.applier = applier;
+    }
+
+    public void apply(Player player, int points) {
+        applier.accept(player, points);
+    }
+
+    private static void apply(Player player, Attribute attrType, String key, double amount, AttributeModifier.Operation op) {
+        var attr = player.getAttribute(attrType);
+        if (attr == null) return;
+        NamespacedKey nsKey = new NamespacedKey(ContinentPlugin.getInstance(), key);
+        for (var mod : List.copyOf(attr.getModifiers())) {
+            if (nsKey.equals(mod.getKey())) {
+                attr.removeModifier(mod);
+            }
+        }
+        if (amount != 0) {
+            attr.addTransientModifier(new AttributeModifier(nsKey, amount, op, EquipmentSlotGroup.ANY));
+        }
+    }
 }

--- a/src/main/java/me/continent/stat/StatsManager.java
+++ b/src/main/java/me/continent/stat/StatsManager.java
@@ -3,7 +3,7 @@ package me.continent.stat;
 import me.continent.ContinentPlugin;
 import me.continent.player.PlayerData;
 import me.continent.player.PlayerDataManager;
-import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
@@ -11,28 +11,8 @@ import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.Color;
-import org.bukkit.NamespacedKey;
-import org.bukkit.inventory.EquipmentSlotGroup;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeModifier;
 
 public class StatsManager {
-
-    private static final NamespacedKey STR_DAMAGE_KEY = new NamespacedKey(ContinentPlugin.getInstance(), "str_damage");
-    private static final NamespacedKey AGI_SPEED_KEY = new NamespacedKey(ContinentPlugin.getInstance(), "agi_speed");
-    private static final NamespacedKey VIT_HEALTH_KEY = new NamespacedKey(ContinentPlugin.getInstance(), "vit_health");
-    private static final NamespacedKey STR_ATTACK_SPEED_KEY = new NamespacedKey(ContinentPlugin.getInstance(), "str_attack_speed");
-    private static final NamespacedKey STR_KNOCKBACK_KEY = new NamespacedKey(ContinentPlugin.getInstance(), "str_knockback");
-
-    private static void applyModifier(Player player, Attribute attrType, NamespacedKey key, double amount, AttributeModifier.Operation op) {
-        var attr = player.getAttribute(attrType);
-        if (attr == null) return;
-        attr.getModifiers().stream().filter(m -> key.equals(m.getKey())).forEach(attr::removeModifier);
-        if (amount != 0) {
-            attr.addTransientModifier(new AttributeModifier(key, amount, op, EquipmentSlotGroup.ANY));
-        }
-    }
 
     public static void checkLevelUp(Player player) {
         PlayerData data = PlayerDataManager.get(player.getUniqueId());
@@ -99,19 +79,8 @@ public class StatsManager {
 
     public static void applyStats(Player player) {
         PlayerStats stats = PlayerDataManager.get(player.getUniqueId()).getStats();
-
-        int str = stats.get(StatType.STRENGTH);
-        int agi = stats.get(StatType.AGILITY);
-        int vit = stats.get(StatType.VITALITY);
-
-        applyModifier(player, Attribute.ATTACK_DAMAGE, STR_DAMAGE_KEY, str * 0.2, AttributeModifier.Operation.ADD_NUMBER);
-        applyModifier(player, Attribute.ATTACK_KNOCKBACK, STR_KNOCKBACK_KEY, str >= 14 ? 1.0 : 0.0, AttributeModifier.Operation.ADD_NUMBER);
-        applyModifier(player, Attribute.ATTACK_SPEED, STR_ATTACK_SPEED_KEY, str >= 10 ? 16.0 : 0.0, AttributeModifier.Operation.ADD_NUMBER);
-        applyModifier(player, Attribute.MOVEMENT_SPEED, AGI_SPEED_KEY, 0.05 * agi, AttributeModifier.Operation.MULTIPLY_SCALAR_1);
-        applyModifier(player, Attribute.MAX_HEALTH, VIT_HEALTH_KEY, vit * 2.0, AttributeModifier.Operation.ADD_NUMBER);
-        var healthAttr = player.getAttribute(Attribute.MAX_HEALTH);
-        if (healthAttr != null && player.getHealth() > healthAttr.getValue()) {
-            player.setHealth(healthAttr.getValue());
+        for (StatType type : StatType.values()) {
+            type.apply(player, stats.get(type));
         }
     }
 }


### PR DESCRIPTION
## Summary
- return read-only invite lists without creating empty entries
- rework player stats to use primitive array with clamped point math
- safely reapply stat modifiers to avoid concurrent modification
- keep agility flight from disabling creative mode and ensure fall damage applies

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6890f154f71c8324bbf97899d0762a45