### PR TITLE
Implement biome trait mechanics

### DIFF
--- a/src/main/java/me/continent/ContinentPlugin.java
+++ b/src/main/java/me/continent/ContinentPlugin.java
@@ -62,6 +62,7 @@ import me.continent.command.ContinentCommand;
 import me.continent.market.pricing.DemandManager;
 import me.continent.market.pricing.MarketLogManager;
 import me.continent.market.pricing.PriceHistoryManager;
+import me.continent.movement.MovementListener;
 
 import java.io.File;
 
@@ -158,6 +159,7 @@ public class ContinentPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new JobMenuListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.StatsEffectListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.DashHandler(), this);
+        getServer().getPluginManager().registerEvents(new MovementListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.StatLevelListener(), this);
         getServer().getPluginManager().registerEvents(new me.continent.listener.LuckDropListener(), this);
         getServer().getPluginManager().registerEvents(new PickpocketManager(), this);

--- a/src/main/java/me/continent/biome/BiomeModifierService.java
+++ b/src/main/java/me/continent/biome/BiomeModifierService.java
@@ -1,8 +1,17 @@
 package me.continent.biome;
 
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Biome;
 import org.bukkit.entity.Player;
 
+/**
+ * Provides helpers for applying biome based economic modifiers.
+ */
 public class BiomeModifierService {
+    /**
+     * Returns the trade category deformation for the player's current biome.
+     */
     public static float getTradeModifier(Player player, String category) {
         BiomeTrait trait = BiomeTraitService.get(player);
         BiomeTrait.TradeDeform td = trait.tradeDeform();
@@ -13,5 +22,40 @@ public class BiomeModifierService {
             case "gem" -> td.gem();
             default -> 0f;
         };
+    }
+
+    /**
+     * Calculates item specific value multipliers based on special rules.
+     */
+    public static float getItemValueMultiplier(Material item, Location loc) {
+        BiomeTrait trait = BiomeTraitService.get(loc);
+        float mult = 1.0f;
+        for (BiomeTrait.Rule rule : trait.rules()) {
+            if (rule.type() == BiomeTrait.RuleType.ELEVATION_TRADE_BONUS) {
+                String target = String.valueOf(rule.params().get("item")).toLowerCase();
+                if (!item.name().toLowerCase().equals(target)) continue;
+                int yMin = ((Number) rule.params().getOrDefault("y_min", 0)).intValue();
+                int radius = ((Number) rule.params().getOrDefault("radius", 0)).intValue();
+                double valueMult = ((Number) rule.params().getOrDefault("value_mult", 1.0)).doubleValue();
+                if (loc.getBlockY() < yMin) continue;
+                if (!isUniformBiome(loc, radius)) continue;
+                mult *= (float) valueMult;
+            }
+        }
+        return mult;
+    }
+
+    private static boolean isUniformBiome(Location loc, int radius) {
+        if (radius <= 0) return true;
+        Biome base = loc.getBlock().getBiome();
+        int step = Math.max(1, radius / 5);
+        for (int x = -radius; x <= radius; x += step) {
+            for (int z = -radius; z <= radius; z += step) {
+                if (loc.getWorld().getBiome(loc.getBlockX() + x, loc.getBlockY(), loc.getBlockZ() + z) != base) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/me/continent/command/AdminCommand.java
+++ b/src/main/java/me/continent/command/AdminCommand.java
@@ -67,6 +67,9 @@ public class AdminCommand implements TabExecutor {
                 sender.sendMessage("§fTags: " + String.join(", ", trait.tags()));
                 sender.sendMessage(String.format("§fbase_temp: %.1f, move_mult: %.2f, crop_rate: %.2f, crop_yield_rate: %.2f",
                         trait.baseTemp(), trait.moveMult(), trait.cropRate(), trait.cropYieldRate()));
+                String rules = trait.rules().stream().map(r -> r.type().name().toLowerCase()).reduce((a,b) -> a + ", " + b).orElse("none");
+                sender.sendMessage("§fRules: " + rules);
+                sender.sendMessage("§fTemp now: " + me.continent.temperature.PlayerTemperatureService.getTemperature(p));
                 return true;
             }
             sender.sendMessage("§c사용법: /admin biome <reload|get>");

--- a/src/main/java/me/continent/crop/CropGrowthManager.java
+++ b/src/main/java/me/continent/crop/CropGrowthManager.java
@@ -1,6 +1,7 @@
 package me.continent.crop;
 
 import me.continent.ContinentPlugin;
+import me.continent.biome.BiomeTraitService;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -58,7 +59,7 @@ public class CropGrowthManager {
         while (it.hasNext()) {
             Map.Entry<Location, CropData> entry = it.next();
             CropData data = entry.getValue();
-            double days = requiredDays(data.type);
+            double days = requiredDays(data.type, data.location);
             long totalMs = (long) (days * 1200_000L); // 1 day = 20min
             if (now - data.start >= totalMs) {
                 Block block = data.location.getBlock();
@@ -84,7 +85,7 @@ public class CropGrowthManager {
             if (target == null) continue;
             CropData data = crops.get(target.getLocation());
             if (data == null) continue;
-            double days = requiredDays(data.type);
+            double days = requiredDays(data.type, data.location);
             long totalMs = (long) (days * 1200_000L);
             long remain = totalMs - (now - data.start);
             if (remain < 0) remain = 0;
@@ -93,8 +94,12 @@ public class CropGrowthManager {
         }
     }
 
-    private static double requiredDays(CropType type) {
-        return type.getBaseDays();
+    private static double requiredDays(CropType type, Location loc) {
+        double baseDays = type.getBaseDays();
+        float rate = BiomeTraitService.get(loc).cropRate();
+        rate = Math.max(0.1f, Math.min(5.0f, rate));
+        // 바이옴 간 성장 시간 비교 테스트 포인트
+        return baseDays / rate;
     }
 
     private static String formatTime(long ms) {

--- a/src/main/java/me/continent/movement/MovementListener.java
+++ b/src/main/java/me/continent/movement/MovementListener.java
@@ -1,0 +1,82 @@
+package me.continent.movement;
+
+import me.continent.biome.BiomeTrait;
+import me.continent.biome.BiomeTraitService;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Applies movement multipliers based on biome traits and special rules.
+ */
+public class MovementListener implements Listener {
+    private static final Map<UUID, Double> BASE_SPEED = new HashMap<>();
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        AttributeInstance attr = event.getPlayer().getAttribute(Attribute.MOVEMENT_SPEED);
+        if (attr != null) {
+            BASE_SPEED.put(event.getPlayer().getUniqueId(), attr.getBaseValue());
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        BASE_SPEED.remove(event.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (event.getFrom().getChunk().equals(event.getTo().getChunk()) &&
+                event.getFrom().getBlock().getBiome() == event.getTo().getBlock().getBiome()) {
+            return; // same chunk and biome
+        }
+        Player player = event.getPlayer();
+        AttributeInstance attr = player.getAttribute(Attribute.MOVEMENT_SPEED);
+        if (attr == null) return;
+        double base = BASE_SPEED.computeIfAbsent(player.getUniqueId(), id -> attr.getBaseValue());
+
+        BiomeTrait trait = BiomeTraitService.get(player);
+        double mult = Math.max(0.1f, Math.min(5.0f, trait.moveMult()));
+        double finalMult = mult;
+
+        boolean leatherImmune = hasLeatherImmunity(player, trait);
+        for (BiomeTrait.Rule rule : trait.rules()) {
+            if (rule.type() == BiomeTrait.RuleType.LOW_LIGHT_SLOW) {
+                int lightMax = ((Number) rule.params().getOrDefault("light_max", 5)).intValue();
+                double ruleMult = ((Number) rule.params().getOrDefault("move_mult", 1.0)).doubleValue();
+                if (!leatherImmune && player.getLocation().getBlock().getLightFromBlocks() <= lightMax) {
+                    finalMult *= ruleMult;
+                }
+            }
+        }
+
+        double target = base * finalMult;
+        if (Math.abs(attr.getBaseValue() - target) > 1e-6) {
+            attr.setBaseValue(target);
+        }
+    }
+
+    private boolean hasLeatherImmunity(Player player, BiomeTrait trait) {
+        boolean rulePresent = trait.rules().stream().anyMatch(r -> r.type() == BiomeTrait.RuleType.LEATHER_IMMUNITY);
+        if (!rulePresent) return false;
+        ItemStack[] armor = player.getInventory().getArmorContents();
+        for (ItemStack piece : armor) {
+            if (piece == null || piece.getType() == Material.AIR) return false;
+            if (!piece.getType().name().startsWith("LEATHER_")) return false;
+        }
+        return true;
+    }
+}
+


### PR DESCRIPTION
## Summary
- parse and cache biome special rules with validation
- adjust crop growth and movement speed using biome multipliers
- expose item value multipliers for elevation bonuses

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_689f28588d248324b25ea59162524889