### PR TITLE
feat: add biome admin commands and resources

### DIFF
--- a/src/main/java/me/continent/command/AdminCommand.java
+++ b/src/main/java/me/continent/command/AdminCommand.java
@@ -61,18 +61,25 @@ public class AdminCommand implements TabExecutor {
                 BiomeTraitService.reloadAsync(sender);
                 return true;
             }
-            if (args.length >= 2 && args[1].equalsIgnoreCase("get") && sender instanceof org.bukkit.entity.Player p) {
+            if (args.length >= 2 && args[1].equalsIgnoreCase("get")) {
+                if (!(sender instanceof org.bukkit.entity.Player p)) {
+                    sender.sendMessage("§c[Continent] Player only");
+                    return true;
+                }
                 var trait = BiomeTraitService.get(p);
-                sender.sendMessage("§6[Biome] §f" + p.getLocation().getBlock().getBiome().name().toLowerCase());
-                sender.sendMessage("§fTags: " + String.join(", ", trait.tags()));
-                sender.sendMessage(String.format("§fbase_temp: %.1f, move_mult: %.2f, crop_rate: %.2f, crop_yield_rate: %.2f",
+                String biomeName = p.getLocation().getBlock().getBiome().name();
+                String tags = trait.tags().isEmpty() ? "-" : String.join(",", trait.tags());
+                sender.sendMessage("§6[Continent] Biome: §e" + biomeName + " §7tags=" + tags);
+                sender.sendMessage(String.format("§6[Continent] base_temp=§e%.1f §6move_mult=§e%.2f §6crop_rate=§e%.2f §6crop_yield_rate=§e%.2f",
                         trait.baseTemp(), trait.moveMult(), trait.cropRate(), trait.cropYieldRate()));
-                String rules = trait.rules().stream().map(r -> r.type().name().toLowerCase()).reduce((a,b) -> a + ", " + b).orElse("none");
-                sender.sendMessage("§fRules: " + rules);
-                sender.sendMessage("§fTemp now: " + me.continent.temperature.PlayerTemperatureService.getTemperature(p));
+                if (!trait.rules().isEmpty()) {
+                    String ruleList = String.join(",", trait.rules().stream()
+                            .map(r -> r.type().name().toLowerCase()).toList());
+                    sender.sendMessage("§6[Continent] rules: §f" + ruleList);
+                }
                 return true;
             }
-            sender.sendMessage("§c사용법: /admin biome <reload|get>");
+            sender.sendMessage("§c[Continent] 사용법: /admin biome <reload|get>");
             return true;
         }
 

--- a/src/main/java/me/continent/command/ContinentCommand.java
+++ b/src/main/java/me/continent/command/ContinentCommand.java
@@ -13,11 +13,10 @@ public class ContinentCommand implements TabExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length >= 2 && args[0].equalsIgnoreCase("biome") && args[1].equalsIgnoreCase("reload")) {
-            BiomeTraitService.reload();
-            sender.sendMessage("§aBiome traits reloaded");
+            BiomeTraitService.reloadAsync(sender);
             return true;
         }
-        sender.sendMessage("§cUsage: /continent biome reload");
+        sender.sendMessage("§c[Continent] Usage: /continent biome reload");
         return true;
     }
 

--- a/src/main/resources/config/biome_traits.yml
+++ b/src/main/resources/config/biome_traits.yml
@@ -1,4 +1,455 @@
-# Default biome traits configuration
+# Generated biome traits
+badlands:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+bamboo_jungle:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+beach:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+birch_forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+cherry_grove:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+cold_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+dark_forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules:
+    - type: LOW_LIGHT_SLOW
+      light_max: 5
+      move_mult: 0.8
+    - type: LEATHER_IMMUNITY
+
+deep_cold_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+deep_dark:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+deep_frozen_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+deep_lukewarm_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+deep_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+desert:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+dripstone_caves:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+eroded_badlands:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+flower_forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+frozen_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+frozen_peaks:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+frozen_river:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+grove:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+ice_spikes:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+jagged_peaks:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules:
+    - type: ELEVATION_TRADE_BONUS
+      y_min: 100
+      radius: 200
+      value_mult: 1.5
+      item: emerald
+
+jungle:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+lukewarm_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+lush_caves:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+mangrove_swamp:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+meadow:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+mushroom_fields:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+old_growth_birch_forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+old_growth_pine_taiga:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+old_growth_spruce_taiga:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+pale_garden:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
 plains:
   base_temp: 20.0
   move_mult: 1.0
@@ -9,16 +460,253 @@ plains:
     metal: 0.0
     leather: 0.0
     gem: 0.0
-  tags: [temperate]
+  tags: []
+  special_rules: []
 
-desert:
-  base_temp: 35.0
+river:
+  base_temp: 20.0
   move_mult: 1.0
   crop_rate: 1.0
   crop_yield_rate: 1.0
   trade_deform:
-    food: 0.2
+    food: 0.0
     metal: 0.0
-    leather: -0.1
+    leather: 0.0
     gem: 0.0
-  tags: [arid]
+  tags: []
+  special_rules: []
+
+savanna:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+savanna_plateau:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+snowy_beach:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+snowy_plains:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+snowy_slopes:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+snowy_taiga:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+sparse_jungle:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+stony_peaks:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+stony_shore:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+sunflower_plains:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+swamp:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+taiga:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+warm_ocean:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+windswept_forest:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+windswept_gravelly_hills:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+windswept_hills:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+windswept_savanna:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+
+wooded_badlands:
+  base_temp: 20.0
+  move_mult: 1.0
+  crop_rate: 1.0
+  crop_yield_rate: 1.0
+  trade_deform:
+    food: 0.0
+    metal: 0.0
+    leather: 0.0
+    gem: 0.0
+  tags: []
+  special_rules: []
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,10 +23,12 @@ commands:
   specialty:
     description: Specialty goods command
     aliases: [spc]
-    usage: /specialty <subcommand>  
+    usage: /specialty <subcommand>
   admin:
-    description: Manage wars, economy, maintenance, scoreboard and config
-    usage: /admin <subcommand>
+    description: Admin commands
+    usage: /admin biome <reload|get>
+    aliases: [ad]
+    permission: continent.admin
   union:
     description: Manage unions of nations
     aliases: [u]
@@ -50,3 +52,7 @@ commands:
   continent:
     description: Continent management commands
     usage: /continent biome reload
+permissions:
+  continent.admin:
+    description: Continent admin permission
+    default: op


### PR DESCRIPTION
## Summary
- add `/admin biome reload|get` with formatted output and prefix
- update plugin.yml and add admin permission
- bundle full biome_traits.yml resource for all overworld biomes
- allow legacy `/continent biome reload`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689f2d424b308324a37ab91399e3f293