### PR TITLE
Fix fall damage not applying unless dash used

### DIFF
--- a/src/main/java/me/continent/listener/DashHandler.java
+++ b/src/main/java/me/continent/listener/DashHandler.java
@@ -57,6 +57,7 @@ public class DashHandler implements Listener {
     private void startCooldown(Player player, UUID id) {
         dashCooldown.add(id);
         player.setAllowFlight(false);
+        player.setFlying(false);
 
         final long totalTicks = COOLDOWN_MS / 50;
         new BukkitRunnable() {
@@ -74,6 +75,7 @@ public class DashHandler implements Listener {
                     player.sendActionBar(Component.empty());
                     if (player.isOnGround()) {
                         player.setAllowFlight(true);
+                        player.setFlying(false);
                     }
                     cancel();
                 }
@@ -91,6 +93,7 @@ public class DashHandler implements Listener {
 
         if (player.isOnGround() && !dashCooldown.contains(player.getUniqueId())) {
             player.setAllowFlight(true);
+            player.setFlying(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure player flight state is reset so fall damage isn't suppressed when using the dash ability

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ebea74d483249be4a4454908a330